### PR TITLE
Update dev env (`2022-11-15`)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !*.nix
 !.shellhook
+!README.md
 !.clang-format
 
 !scripts/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# oclng
+
+Dependencies
+---
+ - [Clang](https://clang.llvm.org/)
+```
+$ clang --version
+clang version 14.0.6
+Target: x86_64-pc-linux-gnu
+Thread model: posix
+InstalledDir: /usr/bin
+```
+ - [flat assembler](https://flatassembler.net/)
+```
+$ fasm
+flat assembler  version 1.73.30
+```
+ - [mold](https://github.com/rui314/mold)
+```
+$ mold --version
+mold 1.6.0 (323ad30e25c2c81efdb07ab76601a119335a40c8; compatible with GNU ld)
+```
+ - [Nix](https://nixos.org/download.html)
+```
+$ nix --version
+nix (Nix) 2.11.1
+```
+
+Quick start
+---
+```
+$ nix-shell
+[nix-shell:path/to/oclng]$ ./scripts/build.sh
+[nix-shell:path/to/oclng]$ ./scripts/test.py
+```

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -24,8 +24,8 @@ flags_c=(
     -Wno-c11-extensions
     -Wno-declaration-after-statement
     -Wno-disabled-macro-expansion
-    -Wno-extra-semi-stmt
     -Wno-incompatible-library-redeclaration
+    -Wno-padded
 )
 flags_fasm=(
     -d "HEAP_CAP=${heap_cap}"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -4,15 +4,9 @@ set -eu
 
 export OCAMLRUNPARAM="b"
 
-flags=(
-    "-fuse-ld=mold"
-    --no-warn-rwx-segments
-    -znoexecstack
-)
-
 "$WD/bin/com" "$1" "$WD/build/main.asm"
 cat "$WD/build/main.asm" >&2
 fasm "$WD/build/main.asm" "$WD/build/main.o" > /dev/null
-ld "${flags[@]}" -o "$WD/bin/run" -lc "$WD/build/runtime_asm.o" \
+mold -run clang -no-pie -o "$WD/bin/run" "$WD/build/runtime_asm.o" \
     "$WD/build/runtime_c.o" "$WD/build/main.o"
 "$WD/bin/run"

--- a/shell.nix
+++ b/shell.nix
@@ -1,16 +1,11 @@
 with import <nixpkgs> {};
-mkShell.override { stdenv = llvmPackages_14.stdenv; } {
+mkShell {
     buildInputs = [
-        fasm
-        mold
-        musl
         ocaml
         ocamlPackages.ocp-indent
         python3Packages.flake8
-        shellcheck
     ];
     shellHook = ''
         . .shellhook
     '';
-    hardeningDisable = [ "all" ];
 }

--- a/src/runtime.asm
+++ b/src/runtime.asm
@@ -1,28 +1,37 @@
 format ELF64
 
-public _start
+public main
 
 extrn fflush
-extrn stdout
+extrn setlinebuf
 extrn stderr
+extrn stdout
 
 extrn print_heap
 
 extrn entry_
 
 section '.text' executable
-    _start:
+    main:
+        push rbp
         mov rbp, rsp
+
+        mov rdi, [stderr]
+        call setlinebuf
+
         call entry_
         push rax
+
         call print_heap
+
         mov rdi, [stdout]
         call fflush
         mov rdi, [stderr]
         call fflush
-        pop rdi
-        mov eax, 60
-        syscall
+
+        pop rax
+        leave
+        ret
 
 public HEAP_MEMORY
 

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -21,7 +21,7 @@ STATIC_ASSERT(sizeof(Bool) == sizeof(u8));
 #define ERROR 1
 
 #define EXIT_IF(condition)             \
-    {                                  \
+    do {                               \
         if (condition) {               \
             fflush(stdout);            \
             fprintf(stderr,            \
@@ -32,7 +32,7 @@ STATIC_ASSERT(sizeof(Bool) == sizeof(u8));
                     #condition);       \
             _exit(ERROR);              \
         }                              \
-    }
+    } while (FALSE)
 
 typedef struct {
     u32  children;


### PR DESCRIPTION
Similar changes to those made over here: https://github.com/albertgoncalves/asmaroto/pull/1 , in spirit of a more portable development environment. `musl` rocks, but I didn't realize some `musl` specific behavior I was relying on, so it's good to see things from `glibc` side of town to catch some hidden snags in the previous setup.